### PR TITLE
Ny pw shoes

### DIFF
--- a/ny_pw_shoes/.ipynb_checkpoints/__init__-checkpoint.py
+++ b/ny_pw_shoes/.ipynb_checkpoints/__init__-checkpoint.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+
+from . import models

--- a/ny_pw_shoes/.ipynb_checkpoints/__manifest__-checkpoint.py
+++ b/ny_pw_shoes/.ipynb_checkpoints/__manifest__-checkpoint.py
@@ -1,0 +1,16 @@
+{
+    'name': 'NY P&W Shoes',
+    'summary': """""",
+    'description': """""",
+    'author': 'Odoo',
+    'website': 'https://www.odoo.com',
+    'category': 'Training',
+    'version': '0.1',
+    'depends': ['sale'],
+    'data': [
+        'views/product_template_view_inherit.xml',
+    ],
+    'demo':[
+        
+    ],
+}

--- a/ny_pw_shoes/__init__.py
+++ b/ny_pw_shoes/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+
+from . import models

--- a/ny_pw_shoes/__manifest__.py
+++ b/ny_pw_shoes/__manifest__.py
@@ -1,0 +1,16 @@
+{
+    'name': 'NY P&W Shoes',
+    'summary': """""",
+    'description': """""",
+    'author': 'Odoo',
+    'website': 'https://www.odoo.com',
+    'category': 'Training',
+    'version': '0.1',
+    'depends': ['sale'],
+    'data': [
+        'views/product_template_view_inherit.xml',
+    ],
+    'demo':[
+        
+    ],
+}

--- a/ny_pw_shoes/models/.ipynb_checkpoints/__init__-checkpoint.py
+++ b/ny_pw_shoes/models/.ipynb_checkpoints/__init__-checkpoint.py
@@ -1,0 +1,1 @@
+from . import product_template

--- a/ny_pw_shoes/models/.ipynb_checkpoints/product_template-checkpoint.py
+++ b/ny_pw_shoes/models/.ipynb_checkpoints/product_template-checkpoint.py
@@ -1,0 +1,12 @@
+
+
+from odoo import models, fields, api
+
+
+class ProductTemplate(models.Model):
+    
+    _inherit = 'product.template'
+    _description = ''
+    
+    pair_per_case = fields.Integer(string='Pair Per Case', default=0)
+    price_per_pair = fields.Monetary(string='Price Per Pair', default=0.00)

--- a/ny_pw_shoes/models/.ipynb_checkpoints/product_template-checkpoint.py
+++ b/ny_pw_shoes/models/.ipynb_checkpoints/product_template-checkpoint.py
@@ -10,7 +10,7 @@ class ProductTemplate(models.Model):
     
     pair_per_case = fields.Integer(string='Pair Per Case', help='this is a helper', default=0)
     price_per_case = fields.Monetary(string='Price Per Pair', default=0.00)
-    is_changed = False
+    ischanged= fields.Boolean(string='Is Changed', default=False)
     
     @api.onchange('pair_per_case', 'price_per_case')
     def _onchange_sales_price(self):
@@ -20,6 +20,6 @@ class ProductTemplate(models.Model):
             raise UserError('Price cannot be less than $0.00')
             
         self.list_price = self.price_per_case * self.pair_per_case
-        is_changed = True
+        self.ischanged = True
     
         

--- a/ny_pw_shoes/models/.ipynb_checkpoints/product_template-checkpoint.py
+++ b/ny_pw_shoes/models/.ipynb_checkpoints/product_template-checkpoint.py
@@ -1,4 +1,4 @@
-
+# -*- coding: utf-8 -*-
 
 from odoo import models, fields, api
 
@@ -9,4 +9,4 @@ class ProductTemplate(models.Model):
     _description = ''
     
     pair_per_case = fields.Integer(string='Pair Per Case', default=0)
-    price_per_pair = fields.Monetary(string='Price Per Pair', default=0.00)
+    price_per_case = fields.Monetary(string='Price Per Pair', default=0.00)

--- a/ny_pw_shoes/models/.ipynb_checkpoints/product_template-checkpoint.py
+++ b/ny_pw_shoes/models/.ipynb_checkpoints/product_template-checkpoint.py
@@ -20,6 +20,7 @@ class ProductTemplate(models.Model):
             raise UserError('Price cannot be less than $0.00')
             
         self.list_price = self.price_per_case * self.pair_per_case
+        self.list_price = {'readonly':True}
         
     
         

--- a/ny_pw_shoes/models/.ipynb_checkpoints/product_template-checkpoint.py
+++ b/ny_pw_shoes/models/.ipynb_checkpoints/product_template-checkpoint.py
@@ -10,7 +10,7 @@ class ProductTemplate(models.Model):
     
     pair_per_case = fields.Integer(string='Pair Per Case', help='this is a helper', default=0)
     price_per_case = fields.Monetary(string='Price Per Pair', default=0.00)
-    
+    is_changed = False
     
     @api.onchange('pair_per_case', 'price_per_case')
     def _onchange_sales_price(self):
@@ -20,7 +20,6 @@ class ProductTemplate(models.Model):
             raise UserError('Price cannot be less than $0.00')
             
         self.list_price = self.price_per_case * self.pair_per_case
-        self.list_price = {'readonly':True}
-        
+        is_changed = True
     
         

--- a/ny_pw_shoes/models/.ipynb_checkpoints/product_template-checkpoint.py
+++ b/ny_pw_shoes/models/.ipynb_checkpoints/product_template-checkpoint.py
@@ -10,7 +10,7 @@ class ProductTemplate(models.Model):
     
     pair_per_case = fields.Integer(string='Pair Per Case', help='this is a helper', default=0)
     price_per_case = fields.Monetary(string='Price Per Pair', default=0.00)
-    ischanged= fields.Boolean(string='Is Changed', default=False)
+    is_changed= fields.Boolean(string='Is Changed', default=False)
     
     @api.onchange('pair_per_case', 'price_per_case')
     def _onchange_sales_price(self):
@@ -20,6 +20,6 @@ class ProductTemplate(models.Model):
             raise UserError('Price cannot be less than $0.00')
             
         self.list_price = self.price_per_case * self.pair_per_case
-        self.ischanged = True
+        self.is_changed = True
     
         

--- a/ny_pw_shoes/models/.ipynb_checkpoints/product_template-checkpoint.py
+++ b/ny_pw_shoes/models/.ipynb_checkpoints/product_template-checkpoint.py
@@ -1,12 +1,25 @@
 # -*- coding: utf-8 -*-
 
 from odoo import models, fields, api
-
+from odoo.exceptions import UserError, ValidationError
 
 class ProductTemplate(models.Model):
     
     _inherit = 'product.template'
     _description = ''
     
-    pair_per_case = fields.Integer(string='Pair Per Case', default=0)
+    pair_per_case = fields.Integer(string='Pair Per Case', help='this is a helper', default=0)
     price_per_case = fields.Monetary(string='Price Per Pair', default=0.00)
+    
+    
+    @api.onchange('pair_per_case', 'price_per_case')
+    def _onchange_sales_price(self):
+        if self.pair_per_case < 0:
+            raise UserError('Pair per case cannot be less than 0')
+        if self.price_per_case < 0.00:
+            raise UserError('Price cannot be less than $0.00')
+            
+        self.list_price = self.price_per_case * self.pair_per_case
+        
+    
+        

--- a/ny_pw_shoes/models/__init__.py
+++ b/ny_pw_shoes/models/__init__.py
@@ -1,0 +1,1 @@
+from . import product_template

--- a/ny_pw_shoes/models/product_template.py
+++ b/ny_pw_shoes/models/product_template.py
@@ -1,0 +1,12 @@
+
+
+from odoo import models, fields, api
+
+
+class ProductTemplate(models.Model):
+    
+    _inherit = 'product.template'
+    _description = ''
+    
+    pair_per_case = fields.Integer(string='Pair Per Case', default=0)
+    price_per_pair = fields.Monetary(string='Price Per Pair', default=0.00)

--- a/ny_pw_shoes/models/product_template.py
+++ b/ny_pw_shoes/models/product_template.py
@@ -10,7 +10,7 @@ class ProductTemplate(models.Model):
     
     pair_per_case = fields.Integer(string='Pair Per Case', help='this is a helper', default=0)
     price_per_case = fields.Monetary(string='Price Per Pair', default=0.00)
-    is_changed = False
+    ischanged= fields.Boolean(string='Is Changed', default=False)
     
     @api.onchange('pair_per_case', 'price_per_case')
     def _onchange_sales_price(self):
@@ -20,6 +20,6 @@ class ProductTemplate(models.Model):
             raise UserError('Price cannot be less than $0.00')
             
         self.list_price = self.price_per_case * self.pair_per_case
-        is_changed = True
+        self.ischanged = True
     
         

--- a/ny_pw_shoes/models/product_template.py
+++ b/ny_pw_shoes/models/product_template.py
@@ -1,4 +1,4 @@
-
+# -*- coding: utf-8 -*-
 
 from odoo import models, fields, api
 
@@ -9,4 +9,4 @@ class ProductTemplate(models.Model):
     _description = ''
     
     pair_per_case = fields.Integer(string='Pair Per Case', default=0)
-    price_per_pair = fields.Monetary(string='Price Per Pair', default=0.00)
+    price_per_case = fields.Monetary(string='Price Per Pair', default=0.00)

--- a/ny_pw_shoes/models/product_template.py
+++ b/ny_pw_shoes/models/product_template.py
@@ -20,6 +20,7 @@ class ProductTemplate(models.Model):
             raise UserError('Price cannot be less than $0.00')
             
         self.list_price = self.price_per_case * self.pair_per_case
+        self.list_price
         
     
         

--- a/ny_pw_shoes/models/product_template.py
+++ b/ny_pw_shoes/models/product_template.py
@@ -10,7 +10,7 @@ class ProductTemplate(models.Model):
     
     pair_per_case = fields.Integer(string='Pair Per Case', help='this is a helper', default=0)
     price_per_case = fields.Monetary(string='Price Per Pair', default=0.00)
-    
+    is_changed = False
     
     @api.onchange('pair_per_case', 'price_per_case')
     def _onchange_sales_price(self):
@@ -20,7 +20,6 @@ class ProductTemplate(models.Model):
             raise UserError('Price cannot be less than $0.00')
             
         self.list_price = self.price_per_case * self.pair_per_case
-        self.list_price
-        
+        is_changed = True
     
         

--- a/ny_pw_shoes/models/product_template.py
+++ b/ny_pw_shoes/models/product_template.py
@@ -10,7 +10,7 @@ class ProductTemplate(models.Model):
     
     pair_per_case = fields.Integer(string='Pair Per Case', help='this is a helper', default=0)
     price_per_case = fields.Monetary(string='Price Per Pair', default=0.00)
-    ischanged= fields.Boolean(string='Is Changed', default=False)
+    is_changed= fields.Boolean(string='Is Changed', default=False)
     
     @api.onchange('pair_per_case', 'price_per_case')
     def _onchange_sales_price(self):
@@ -20,6 +20,6 @@ class ProductTemplate(models.Model):
             raise UserError('Price cannot be less than $0.00')
             
         self.list_price = self.price_per_case * self.pair_per_case
-        self.ischanged = True
+        self.is_changed = True
     
         

--- a/ny_pw_shoes/models/product_template.py
+++ b/ny_pw_shoes/models/product_template.py
@@ -1,12 +1,25 @@
 # -*- coding: utf-8 -*-
 
 from odoo import models, fields, api
-
+from odoo.exceptions import UserError, ValidationError
 
 class ProductTemplate(models.Model):
     
     _inherit = 'product.template'
     _description = ''
     
-    pair_per_case = fields.Integer(string='Pair Per Case', default=0)
+    pair_per_case = fields.Integer(string='Pair Per Case', help='this is a helper', default=0)
     price_per_case = fields.Monetary(string='Price Per Pair', default=0.00)
+    
+    
+    @api.onchange('pair_per_case', 'price_per_case')
+    def _onchange_sales_price(self):
+        if self.pair_per_case < 0:
+            raise UserError('Pair per case cannot be less than 0')
+        if self.price_per_case < 0.00:
+            raise UserError('Price cannot be less than $0.00')
+            
+        self.list_price = self.price_per_case * self.pair_per_case
+        
+    
+        

--- a/ny_pw_shoes/views/.ipynb_checkpoints/product_template_view_inherit-checkpoint.xml
+++ b/ny_pw_shoes/views/.ipynb_checkpoints/product_template_view_inherit-checkpoint.xml
@@ -7,9 +7,12 @@
             <field name="model">product.template</field>
             <field name="inherit_id" ref="product.product_template_only_form_view"/>
             <field name="arch" type="xml">
+                <xpath expr="//field[@name='list_price']" position="attributes">
+                    <attribute name="attrs">{'readonly':[('is_changed','=', True)]}</attribute>
+                </xpath>
                 <xpath expr="//field[@name='barcode']" position="after">
-                    <field name="list_price" position="move" />
-                    <field name="pair_per_case" attrs="{'readonly':[('ischanged','=',True)]}"/>
+                    <field name='is_changed' invisible="1"/>
+                    <field name="pair_per_case" />
                     <field name="price_per_case"/>
                 </xpath>
             </field>

--- a/ny_pw_shoes/views/.ipynb_checkpoints/product_template_view_inherit-checkpoint.xml
+++ b/ny_pw_shoes/views/.ipynb_checkpoints/product_template_view_inherit-checkpoint.xml
@@ -7,10 +7,11 @@
             <field name="model">product.template</field>
             <field name="inherit_id" ref="product.product_template_only_form_view"/>
             <field name="arch" type="xml">
+                <xpath expr="//field[@name='list_price']" position="replace"/>
                 <xpath expr="//field[@name='barcode']" position="after">
                     <field name="pair_per_case"/>
                     <field name="price_per_case"/>
-                    <field name="list_price" position="move" attrs="{'readonly':[('is_changed','=',True)]}"/>
+                    <field name="list_price"/>
                 </xpath>
             </field>
         </record>

--- a/ny_pw_shoes/views/.ipynb_checkpoints/product_template_view_inherit-checkpoint.xml
+++ b/ny_pw_shoes/views/.ipynb_checkpoints/product_template_view_inherit-checkpoint.xml
@@ -10,7 +10,7 @@
                 <xpath expr="//field[@name='barcode']" position="after">
                     <field name="pair_per_case"/>
                     <field name="price_per_case"/>
-                    <field name="list_price"/>
+                    <field name="list_price" position="move" attrs="{'readonly':[('is_changed','=',True)]}"/>
                 </xpath>
             </field>
         </record>

--- a/ny_pw_shoes/views/.ipynb_checkpoints/product_template_view_inherit-checkpoint.xml
+++ b/ny_pw_shoes/views/.ipynb_checkpoints/product_template_view_inherit-checkpoint.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<odoo>
+    <data>
+        <record model="ir.ui.view" id="product_template_inherit_shoes_view_form">
+            <field name="name">product.template.inherit.shoes</field>
+            <field name="model">product.template</field>
+            <field name="inherit_id" ref="product.product_template_only_form_view"/>
+            <field name="arch" type="xml">
+                <xpath expr="//field[@name='list_price']" position="before">
+                    <field name="pair_per_case"/>
+                    <field name="price_per_case"/>
+                </xpath>
+            </field>
+        </record>
+    </data>
+</odoo>

--- a/ny_pw_shoes/views/.ipynb_checkpoints/product_template_view_inherit-checkpoint.xml
+++ b/ny_pw_shoes/views/.ipynb_checkpoints/product_template_view_inherit-checkpoint.xml
@@ -6,7 +6,6 @@
             <field name="name">product.template.inherit.shoes</field>
             <field name="model">product.template</field>
             <field name="inherit_id" ref="product.product_template_only_form_view"/>
-            <field name="list_price" read>
             <field name="arch" type="xml">
                 <xpath expr="//field[@name='barcode']" position="after">
                     <field name="pair_per_case"/>

--- a/ny_pw_shoes/views/.ipynb_checkpoints/product_template_view_inherit-checkpoint.xml
+++ b/ny_pw_shoes/views/.ipynb_checkpoints/product_template_view_inherit-checkpoint.xml
@@ -6,10 +6,12 @@
             <field name="name">product.template.inherit.shoes</field>
             <field name="model">product.template</field>
             <field name="inherit_id" ref="product.product_template_only_form_view"/>
+            <field name="list_price" read>
             <field name="arch" type="xml">
                 <xpath expr="//field[@name='barcode']" position="after">
                     <field name="pair_per_case"/>
                     <field name="price_per_case"/>
+                    <field name="list_price"/>
                 </xpath>
             </field>
         </record>

--- a/ny_pw_shoes/views/.ipynb_checkpoints/product_template_view_inherit-checkpoint.xml
+++ b/ny_pw_shoes/views/.ipynb_checkpoints/product_template_view_inherit-checkpoint.xml
@@ -7,11 +7,10 @@
             <field name="model">product.template</field>
             <field name="inherit_id" ref="product.product_template_only_form_view"/>
             <field name="arch" type="xml">
-                <xpath expr="//field[@name='list_price']" position="replace"/>
                 <xpath expr="//field[@name='barcode']" position="after">
-                    <field name="pair_per_case"/>
+                    <field name="list_price" position="move" />
+                    <field name="pair_per_case" attrs="{'readonly':[('ischanged','=',True)]}"/>
                     <field name="price_per_case"/>
-                    <field name="list_price"/>
                 </xpath>
             </field>
         </record>

--- a/ny_pw_shoes/views/.ipynb_checkpoints/product_template_view_inherit-checkpoint.xml
+++ b/ny_pw_shoes/views/.ipynb_checkpoints/product_template_view_inherit-checkpoint.xml
@@ -7,7 +7,7 @@
             <field name="model">product.template</field>
             <field name="inherit_id" ref="product.product_template_only_form_view"/>
             <field name="arch" type="xml">
-                <xpath expr="//field[@name='list_price']" position="before">
+                <xpath expr="//field[@name='barcode']" position="after">
                     <field name="pair_per_case"/>
                     <field name="price_per_case"/>
                 </xpath>

--- a/ny_pw_shoes/views/product_template_view_inherit.xml
+++ b/ny_pw_shoes/views/product_template_view_inherit.xml
@@ -7,9 +7,12 @@
             <field name="model">product.template</field>
             <field name="inherit_id" ref="product.product_template_only_form_view"/>
             <field name="arch" type="xml">
+                <xpath expr="//field[@name='list_price']" position="attributes">
+                    <attribute name="attrs">{'readonly':[('is_changed','=', True)]}</attribute>
+                </xpath>
                 <xpath expr="//field[@name='barcode']" position="after">
-                    <field name="list_price" position="move" />
-                    <field name="pair_per_case" attrs="{'readonly':[('ischanged','=',True)]}"/>
+                    <field name='is_changed' invisible="1"/>
+                    <field name="pair_per_case" />
                     <field name="price_per_case"/>
                 </xpath>
             </field>

--- a/ny_pw_shoes/views/product_template_view_inherit.xml
+++ b/ny_pw_shoes/views/product_template_view_inherit.xml
@@ -7,10 +7,11 @@
             <field name="model">product.template</field>
             <field name="inherit_id" ref="product.product_template_only_form_view"/>
             <field name="arch" type="xml">
+                <xpath expr="//field[@name='list_price']" position="replace"/>
                 <xpath expr="//field[@name='barcode']" position="after">
                     <field name="pair_per_case"/>
                     <field name="price_per_case"/>
-                    <field name="list_price" position="move" attrs="{'readonly':[('is_changed','=',True)]}"/>
+                    <field name="list_price"/>
                 </xpath>
             </field>
         </record>

--- a/ny_pw_shoes/views/product_template_view_inherit.xml
+++ b/ny_pw_shoes/views/product_template_view_inherit.xml
@@ -10,7 +10,7 @@
                 <xpath expr="//field[@name='barcode']" position="after">
                     <field name="pair_per_case"/>
                     <field name="price_per_case"/>
-                    <field name="list_price"/>
+                    <field name="list_price" position="move" attrs="{'readonly':[('is_changed','=',True)]}"/>
                 </xpath>
             </field>
         </record>

--- a/ny_pw_shoes/views/product_template_view_inherit.xml
+++ b/ny_pw_shoes/views/product_template_view_inherit.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<odoo>
+    <data>
+        <record model="ir.ui.view" id="product_template_inherit_shoes_view_form">
+            <field name="name">product.template.inherit.shoes</field>
+            <field name="model">product.template</field>
+            <field name="inherit_id" ref="product.product_template_only_form_view"/>
+            <field name="arch" type="xml">
+                <xpath expr="//field[@name='list_price']" position="before">
+                    <field name="pair_per_case"/>
+                    <field name="price_per_case"/>
+                </xpath>
+            </field>
+        </record>
+    </data>
+</odoo>

--- a/ny_pw_shoes/views/product_template_view_inherit.xml
+++ b/ny_pw_shoes/views/product_template_view_inherit.xml
@@ -6,7 +6,6 @@
             <field name="name">product.template.inherit.shoes</field>
             <field name="model">product.template</field>
             <field name="inherit_id" ref="product.product_template_only_form_view"/>
-            <field name="list_price" read>
             <field name="arch" type="xml">
                 <xpath expr="//field[@name='barcode']" position="after">
                     <field name="pair_per_case"/>

--- a/ny_pw_shoes/views/product_template_view_inherit.xml
+++ b/ny_pw_shoes/views/product_template_view_inherit.xml
@@ -6,10 +6,12 @@
             <field name="name">product.template.inherit.shoes</field>
             <field name="model">product.template</field>
             <field name="inherit_id" ref="product.product_template_only_form_view"/>
+            <field name="list_price" read>
             <field name="arch" type="xml">
                 <xpath expr="//field[@name='barcode']" position="after">
                     <field name="pair_per_case"/>
                     <field name="price_per_case"/>
+                    <field name="list_price"/>
                 </xpath>
             </field>
         </record>

--- a/ny_pw_shoes/views/product_template_view_inherit.xml
+++ b/ny_pw_shoes/views/product_template_view_inherit.xml
@@ -7,11 +7,10 @@
             <field name="model">product.template</field>
             <field name="inherit_id" ref="product.product_template_only_form_view"/>
             <field name="arch" type="xml">
-                <xpath expr="//field[@name='list_price']" position="replace"/>
                 <xpath expr="//field[@name='barcode']" position="after">
-                    <field name="pair_per_case"/>
+                    <field name="list_price" position="move" />
+                    <field name="pair_per_case" attrs="{'readonly':[('ischanged','=',True)]}"/>
                     <field name="price_per_case"/>
-                    <field name="list_price"/>
                 </xpath>
             </field>
         </record>

--- a/ny_pw_shoes/views/product_template_view_inherit.xml
+++ b/ny_pw_shoes/views/product_template_view_inherit.xml
@@ -7,7 +7,7 @@
             <field name="model">product.template</field>
             <field name="inherit_id" ref="product.product_template_only_form_view"/>
             <field name="arch" type="xml">
-                <xpath expr="//field[@name='list_price']" position="before">
+                <xpath expr="//field[@name='barcode']" position="after">
                     <field name="pair_per_case"/>
                     <field name="price_per_case"/>
                 </xpath>


### PR DESCRIPTION
[bikh]: NY P&W Shoes : Auto-calculated price

NY P&W Shoes is a shoe distributor in New York. They buy shoes in large quantities from China and redistribute them here in the US. They negotiate prices per pair but they sell by case and buy by the case. 

Specification :
This development should be done in the product.template model. 

Requirement 1 –  Adding new field that will be used in the price calculation
Pair per Case - This field will be used to enter an integer which is the number of pair of shoes in the case
Price per Pair - This field will be used to enter the price per pair. It can be a monetary field. 

Requirement 2 –  Make the Sales Price a calculated field
Sales Price - This field uses the pair per case and price per pair to calculate the Sales price (Pair per price X Price per Pair). If nothing is entered in the Pair per Case and Price per Pair, the Sales price should be editable. If something is entered in Pair per Price or Price per Pair, the field should be read-only. 